### PR TITLE
[Feature] Tags컴포넌트 props 설정

### DIFF
--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -1,26 +1,32 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
+import { X } from 'lucide-react';
 
 import { colors } from '@/styles/colors';
 
-function Tags() {
+function Tags({ tags, deletable = false }: TagsProps) {
   return (
-    <ul css={tags}>
-      <li>윤하</li>
-      <li>라이브</li>
-      <li>페스티벌</li>
-      <li>뷰티풀 민트 라이프</li>
+    <ul css={tagWrap(deletable)}>
+      {tags.map((tag) => (
+        <li>
+          {tag}
+          <span className="del">
+            <X size={15} />
+          </span>
+        </li>
+      ))}
     </ul>
   );
 }
 
 export default Tags;
 
-const tags = css`
+const tagWrap = (deletable: boolean) => css`
   display: flex;
   align-items: center;
   gap: 5px;
   li {
+    position: relative;
     display: flex;
     align-items: center;
     height: 25px;
@@ -30,5 +36,29 @@ const tags = css`
     font-weight: 700;
     padding: 0 13px;
     color: ${colors.white};
+    .del {
+      display: none;
+      position: absolute;
+      top: -10px;
+      right: -6px;
+    }
   }
+
+  ${deletable &&
+  `
+    li:hover{
+      cursor: pointer;
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 6px;
+      .del{
+        display:block
+      }
+    }
+    
+  `}
 `;
+
+interface TagsProps {
+  tags: string[];
+  deletable?: boolean;
+}

--- a/src/components/watch/PlaylistInfo.tsx
+++ b/src/components/watch/PlaylistInfo.tsx
@@ -71,7 +71,7 @@ function PlaylistInfo() {
           <Button size="md">
             <Heart size="18" /> <span>244</span>
           </Button>
-          <Tags />
+          <Tags tags={['윤하', '라이브', ' 페스티벌', '뷰티풀 민트 라이프']} />
         </div>
       </div>
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

Tags 컴포넌트 재사용을 위해 props 설정

## 📋 작업 내용
tags, deletable 추가
<Tags tags={['tag1','tag2']} deletable={true} />
tags는 필수값이며 태그(string)를 배열에 담아 보내주시면 됩니다.
deletable은 필수값이 아니며 기본값은 false입니다.

## 📸 스크린샷 (선택 사항)
deletable={true} 일 경우
<img width="309" alt="image" src="https://github.com/user-attachments/assets/b5b024ee-8f1f-4035-a2da-95deecaaa9ed">


