### PR TITLE
[design] 닷메뉴, 드롭다운, 그리드 화면 꽉차게 변경

### DIFF
--- a/src/components/Cover.tsx
+++ b/src/components/Cover.tsx
@@ -1,10 +1,48 @@
-import { ListVideoIcon } from 'lucide-react';
-const Cover = () => {
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { ListVideo } from 'lucide-react';
+
+interface CoverProps {
+  imageSrc: string;
+  playListLength?: number;
+}
+
+const Cover: React.FC<CoverProps> = ({ imageSrc, playListLength }) => {
   return (
-    <div>
-      <ListVideoIcon />;
+    <div css={coverStyle}>
+      <img src={imageSrc} alt="cover" css={coverImageStyle} />
+      {playListLength && (
+        <div css={overlayTextStyle}>
+          {<ListVideo />}
+          {playListLength}
+        </div>
+      )}
     </div>
   );
 };
+
+const coverStyle = css`
+  position: relative;
+  width: 100%;
+  height: 140px; /* 원하는 높이로 설정 */
+`;
+
+const coverImageStyle = css`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+`;
+
+const overlayTextStyle = css`
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  padding: 4px 4px;
+  border-radius: 4px;
+  font-size: 12px;
+`;
 
 export default Cover;

--- a/src/components/MenuDot.tsx
+++ b/src/components/MenuDot.tsx
@@ -1,0 +1,17 @@
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+import { EllipsisVertical } from 'lucide-react';
+const MenuDot = () => {
+  return (
+    <div css={menuDotStyle}>
+      <EllipsisVertical />
+    </div>
+  );
+};
+
+const menuDotStyle = css`
+  margin-top: 10px;
+`;
+
+export default MenuDot;

--- a/src/components/MenuDot.tsx
+++ b/src/components/MenuDot.tsx
@@ -59,7 +59,7 @@ const dropdownMenuStyle = css`
   position: absolute;
   top: 30px;
   right: 0;
-  background-color: ${colors.gray};
+  background-color: ${colors.lightblack};
   border: 1px solid #ddd;
   border-radius: 5px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
@@ -74,7 +74,7 @@ const menuItemStyle = css`
   cursor: pointer;
   font-size: 12px;
   color: ${colors.white};
-  border-bottom: 1px solid white;
+  border-bottom: 1px solid #6d6d6d;
 
   &:hover {
     background-color: ${colors.lightGray};

--- a/src/components/MenuDot.tsx
+++ b/src/components/MenuDot.tsx
@@ -1,17 +1,85 @@
 /** @jsxImportSource @emotion/react */
 
+import { colors } from '@/styles/colors';
 import { css } from '@emotion/react';
-import { EllipsisVertical } from 'lucide-react';
+import { EllipsisVertical, Pencil, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 const MenuDot = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleEdit = () => {
+    console.log('Edit clicked');
+    setIsOpen(false);
+  };
+
+  const handleDelete = () => {
+    console.log('Delete clicked');
+    setIsOpen(false);
+  };
+
   return (
-    <div css={menuDotStyle}>
-      <EllipsisVertical />
+    <div css={menuDotContainerStyle}>
+      <div css={menuDotStyle} onClick={toggleMenu}>
+        <EllipsisVertical />
+      </div>
+      {isOpen && (
+        <div css={dropdownMenuStyle}>
+          <div css={menuItemStyle} onClick={handleEdit}>
+            <Pencil />
+            <p css={menuTextStyle}>수정</p>
+          </div>
+          <div css={menuItemStyle} onClick={handleDelete}>
+            <Trash2 />
+            <p css={menuTextStyle}>삭제</p>
+          </div>
+        </div>
+      )}
     </div>
   );
 };
 
+const menuDotContainerStyle = css`
+  position: relative;
+  display: inline-block;
+`;
+
 const menuDotStyle = css`
   margin-top: 10px;
+  cursor: pointer;
+`;
+
+const dropdownMenuStyle = css`
+  position: absolute;
+  top: 30px;
+  right: 0;
+  background-color: ${colors.gray};
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  min-width: 80px;
+`;
+
+const menuItemStyle = css`
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 12px;
+  color: ${colors.white};
+  border-bottom: 1px solid white;
+
+  &:hover {
+    background-color: ${colors.lightGray};
+  }
+`;
+
+const menuTextStyle = css`
+  margin-top: 8px;
 `;
 
 export default MenuDot;

--- a/src/components/MenuDot.tsx
+++ b/src/components/MenuDot.tsx
@@ -1,9 +1,12 @@
 /** @jsxImportSource @emotion/react */
 
-import { colors } from '@/styles/colors';
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
 import { EllipsisVertical, Pencil, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+
+import { colors } from '@/styles/colors';
+
 const MenuDot = () => {
   const [isOpen, setIsOpen] = useState(false);
 

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -24,6 +24,7 @@ export default Tags;
 const tagWrap = (deletable: boolean) => css`
   display: flex;
   align-items: center;
+  justify-content: end;
   gap: 5px;
   li {
     position: relative;

--- a/src/components/VideoGridItem.tsx
+++ b/src/components/VideoGridItem.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource @emotion/react */
-
 import { css } from '@emotion/react';
 
 import { colors } from '@/styles/colors';
 
+import Cover from './Cover'; // Cover 컴포넌트 추가
 import User from './User';
 
 interface VideoGridItemProps {
@@ -17,7 +17,8 @@ const VideoGridItem: React.FC<VideoGridItemProps> = ({ videoId, title }) => {
 
   return (
     <div css={gridItemStyle}>
-      <img src={thumbnailUrl} alt={title} css={thumbnailStyle} />
+      {/* Cover 컴포넌트로 이미지 감싸기 */}
+      <Cover imageSrc={thumbnailUrl} playListLength={8} />
       <div css={infoStyle}>
         <h3 css={titleStyle}>{title}</h3>
         <User profileimage="없음" nickname="손성오" userid="son" onlyImage={false} />
@@ -39,13 +40,6 @@ const gridItemStyle = css`
   height: 250px;
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-`;
-
-const thumbnailStyle = css`
-  width: 100%;
-  height: 140px;
-  object-fit: cover;
-  border-radius: 12px;
 `;
 
 const infoStyle = css`

--- a/src/components/VideoGridItem.tsx
+++ b/src/components/VideoGridItem.tsx
@@ -4,6 +4,8 @@ import { css } from '@emotion/react';
 import { colors } from '@/styles/colors';
 
 import Cover from './Cover'; // Cover 컴포넌트 추가
+import MenuDot from './MenuDot';
+import Tags from './Tags';
 import User from './User';
 
 interface VideoGridItemProps {
@@ -19,16 +21,16 @@ const VideoGridItem: React.FC<VideoGridItemProps> = ({ videoId, title }) => {
     <div css={gridItemStyle}>
       {/* Cover 컴포넌트로 이미지 감싸기 */}
       <Cover imageSrc={thumbnailUrl} playListLength={8} />
-      <div css={infoStyle}>
-        <h3 css={titleStyle}>{title}</h3>
-        <User profileimage="없음" nickname="손성오" userid="son" onlyImage={false} />
+      <div css={descriptionStyle}>
+        <div css={infoStyle}>
+          <h3 css={titleStyle}>{title}</h3>
+          <User profileimage="없음" nickname="손성오" userid="son" onlyImage={false} />
+        </div>
+        <div>
+          <MenuDot />
+        </div>
       </div>
-      <div css={tagGroupStyle}>
-        <div css={tagStyle}>게임</div>
-        <div css={tagStyle}>게임</div>
-        <div css={tagStyle}>게임</div>
-        <div css={tagStyle}>게임</div>
-      </div>
+      <Tags tags={['게임', '재미', '음악', '힐링']} />
     </div>
   );
 };
@@ -42,6 +44,11 @@ const gridItemStyle = css`
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 `;
 
+const descriptionStyle = css`
+  display: flex;
+  justify-content: space-between;
+`;
+
 const infoStyle = css`
   padding: 10px;
   text-align: left;
@@ -53,28 +60,6 @@ const titleStyle = css`
   font-size: 16px;
   font-weight: bold;
   color: ${colors.white};
-`;
-
-const tagGroupStyle = css`
-  display: flex;
-  justify-content: space-around;
-  padding: 2px;
-`;
-
-const tagStyle = css`
-  flex: 1;
-  margin: 0 5px;
-  padding: 4px;
-  background-color: transparent;
-  border: 1px solid ${colors.tagBoxGray};
-  border-radius: 4px;
-  text-align: center;
-  font-size: 12px;
-  color: ${colors.tagBoxGray};
-
-  &:hover {
-    background-color: #f0f0f0;
-  }
 `;
 
 export default VideoGridItem;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -90,7 +90,7 @@ const Home: React.FC = () => {
 // 스타일 정의
 const containerStyle = css`
   width: 100%;
-  max-width: 1200px;
+
   margin: 0 auto;
   margin-top: 40px;
 `;
@@ -160,12 +160,13 @@ const SeeMore = css`
     border-radius: 5px;
   }
 `;
-
 const gridContainerStyle = css`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); /* 가로로 자동 조정 */
+  grid-auto-rows: minmax(250px, auto); /* 세로로 자동 조정 */
   gap: 20px;
   padding: 20px;
+  width: 100%; /* 그리드 컨테이너의 너비를 100%로 설정 */
 
   @media (min-width: 600px) {
     grid-template-columns: repeat(2, 1fr);
@@ -179,5 +180,4 @@ const gridContainerStyle = css`
     grid-template-columns: repeat(4, 1fr);
   }
 `;
-
 export default Home;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,6 +1,7 @@
 export const colors = {
   primaryGreen: '#00FFA3',
   black: '#131516',
+  lightblack: '#282828',
   red: '#FF6363',
   darkestGray: '#333D4B',
   gray: '#6B6B6B',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

닷메뉴, 드롭다운, 그리드 화면 꽉차게 변경

## 📋 작업 내용

닷메뉴, 드롭다운, 그리드 화면 꽉차게 변경

## 🔧 변경 사항

닷메뉴, 드롭다운, 그리드 화면 꽉차게 변경

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/fa5217d1-6774-4aa7-9d18-15937d176126)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
