### PR TITLE
[bug] managePlaylist페이지 기능오류 및 스타일 수정 

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -54,5 +54,8 @@ const btn = (size: Size, background: boolean) => css`
   `
     background-color: ${colors.white};
     color: ${colors.black};
+    &:hover {
+      background-color: ${colors.primaryGreen};
+    }
   `}
 `;

--- a/src/components/MenuDot.tsx
+++ b/src/components/MenuDot.tsx
@@ -12,7 +12,7 @@ interface MenuDotProps {
   showDelete?: boolean;
   deleteItem?: (index: number) => void;
   index?: number;
-  videoId: string;
+  videoId?: string;
 }
 
 const MenuDot: React.FC<MenuDotProps> = ({

--- a/src/components/managePlaylist/DraggableItem.tsx
+++ b/src/components/managePlaylist/DraggableItem.tsx
@@ -53,7 +53,7 @@ const DraggableItem: React.FC<DraggableItemProps> = ({
         <p>{youTubelistData?.title}</p>
         <span>{youTubelistData?.channelTitle}</span>
       </div>
-      <div css={{ position: 'absolute', right: '20px', top: '15px' }}>
+      <div css={{ position: 'absolute', right: '10px', top: '8px' }}>
         <MenuDot showEdit={false} deleteItem={handleDeletePlaylist} index={index} />
       </div>
     </div>
@@ -79,7 +79,7 @@ const videoArea = (imgUrl?: string) => css`
   `}
 `;
 const listArea = css`
-  width: 100%;
+  width: 98%;
   height: 180px;
   display: flex;
   justify-content: flex-start;
@@ -89,7 +89,7 @@ const listArea = css`
   border-radius: 10px;
   position: relative;
   :hover {
-    background-color: #585858;
+    background-color: #242424;
   }
 `;
 const youtubeDataArea = css`
@@ -97,10 +97,10 @@ const youtubeDataArea = css`
   align-items: top;
   flex-direction: column;
   height: 100%;
-  padding-top: 20px;
+  padding: 20px 30px 0 0;
   & p {
     color: ${colors.white};
-    font-size: 22px;
+    font-size: 18px;
     margin-bottom: 20px;
   }
   & span {

--- a/src/components/managePlaylist/PlaylistChart.tsx
+++ b/src/components/managePlaylist/PlaylistChart.tsx
@@ -22,8 +22,8 @@ const PlaylistChart: React.FC = () => {
   };
 
   return (
-    <DndProvider backend={HTML5Backend}>
-      <div css={playlistChartWrapper('top')}>
+    <div css={playlistChartWrapper('top')}>
+      <DndProvider backend={HTML5Backend}>
         {youTubelistData ? (
           <ul css={{ width: '100%' }}>
             {youTubelistData.map((youTubelistData, index) => (
@@ -42,8 +42,8 @@ const PlaylistChart: React.FC = () => {
             <p>영상을 추가해 보새요.</p>
           </div>
         )}
-      </div>
-    </DndProvider>
+      </DndProvider>
+    </div>
   );
 };
 
@@ -51,7 +51,7 @@ export default PlaylistChart;
 
 const playlistChartWrapper = (position: string) => css`
   width: 100%;
-  min-height: 800px;
+  max-height: 800px;
   margin-left: 20px;
   box-sizing: border-box;
   display: flex;
@@ -59,8 +59,15 @@ const playlistChartWrapper = (position: string) => css`
   align-items: ${position};
   font-size: 22px;
   color: #6b6b6b;
-  transition: all 0.4;
+  overflow-y: auto;
   & p {
     margin-left: 10px;
+  }
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #242424;
+    border-radius: 10px;
   }
 `;

--- a/src/pages/ManagePlaylist.tsx
+++ b/src/pages/ManagePlaylist.tsx
@@ -24,10 +24,10 @@ const ManagePlaylist = () => {
   const clearYoutubelistData = useYoutubeDataStore((state) => state.clearYoutubelistData);
   const playlistDataToAdd = useRef<{ getPlaylistData: () => PlaylistDataStore }>(null);
   const { playlistId } = useParams() as { playlistId: string };
-  const { mutate } = useNewPlaylist();
-  const navigate = useNavigate();
   const { data: youtubeResults } = useYoutubeFetch(videoIdList, !!videoIdList);
   const { data: userPlyData } = useWatchDataFetch(playlistId, 'Edit', !!playlistId);
+  const { mutate } = useNewPlaylist();
+  const navigate = useNavigate();
 
   useEffect(() => {
     youtubeResults?.items.forEach((data) => {
@@ -82,25 +82,20 @@ const ManagePlaylist = () => {
       try {
         mutate({ playlistData, type, playlistId });
         if (type === '추가') {
-          clearYoutubelistData();
           toast.success('플레이리스트가 생성되었습니다.');
-          setTimeout(() => {
-            navigate('/playlist');
-          }, 2000);
         } else if (type === '수정') {
-          clearYoutubelistData();
           toast.success('플레이리스트가 수정되었습니다.');
-          setTimeout(() => {
-            navigate(`/watch/${playlistId}?v=${addedPlaylist[0].id}`);
-          }, 2000);
         }
+        setTimeout(() => {
+          clearYoutubelistData();
+          navigate('/playlist');
+        }, 2000);
       } catch (error) {
         toast.error('플레이리스트 업데이트 중 오류가 발생하였습니다. 다시 시도해주세요.');
         console.error(error);
       }
     }
   };
-  console.log(addedPlaylist[0]?.id);
   return (
     <div css={{ margin: '5px 15px 0 0' }}>
       <h2 css={{ fontSize: '22px', marginBottom: '20px' }}>
@@ -111,7 +106,9 @@ const ManagePlaylist = () => {
         <div css={{ width: 'calc(100% - 450px)', position: 'relative' }}>
           <PlaylistChart />
           <div css={btnArea}>
-            <Button size="md">취소</Button>
+            <Button size="md" onClick={() => history.back()}>
+              취소
+            </Button>
             <Button
               size="md"
               background={true}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항
### 기능
- 썸내일 항상 앞에 있는걸로 되게끔 수정
- 플리추가 취소 navigation 연결
- 공개여부 변경 적용안되는 오류 해결
- 제목 22자, 태그 8자 제한 추가
- 수정완료 후 라우팅 playlist페이지로 가도록 수정

### 스타일
- 완료버튼 호버색상 변경
- 유투브 영상 제목 폰트 줄임
- 목록 스크롤 생성

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
